### PR TITLE
Add script to create loopback mount 

### DIFF
--- a/dind-jenkins-ansible/Dockerfile
+++ b/dind-jenkins-ansible/Dockerfile
@@ -41,8 +41,8 @@ RUN echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/
 RUN gpasswd -a jenkins docker
 
 # Install the magic wrapper
-ADD ./wrapdocker /usr/local/bin/wrapdocker
-RUN chmod +x /usr/local/bin/wrapdocker
+ADD ./wrapdocker /usr/local/bin/wrapdocker ./addloop.sh /usr/local/bin/addloop
+RUN chmod +x /usr/local/bin/wrapdocker /usr/local/bin/addloop
 
 ENV DOCKER_DAEMON_ARGS='--storage-opt dm.basesize=100G'
 

--- a/dind-jenkins-ansible/addloop.sh
+++ b/dind-jenkins-ansible/addloop.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+ensure_loop(){
+  num="$1"
+  dev="/dev/loop$num"
+  if test -b "$dev"; then
+    echo "$dev is a usable loop device."
+    return 0
+  fi
+
+  echo "Attempting to create $dev for docker ..."
+  if ! mknod -m660 $dev b 7 $num; then
+    echo "Failed to create $dev!" 1>&2
+    return 3
+  fi
+
+  return 0
+}
+
+LOOP_A=$(losetup -f)
+LOOP_A=${LOOP_A#/dev/loop}
+LOOP_B=$(expr $LOOP_A + 1)
+
+ensure_loop $LOOP_A
+ensure_loop $LOOP_B


### PR DESCRIPTION
The script to use when docker fails with `loopback mounting failed` , in that case run this script inside the container as `source /usr/local/bin/addloop` and restart docker daemon `docker -d $DOCKER_ARGS` , if needed remove `/var/run/docker.pid` and run docker daemon again, this time it should run safely )
